### PR TITLE
Fix incorrect display of memory/cpu usage for commands which spawn children

### DIFF
--- a/include/procman/procinfo.hpp
+++ b/include/procman/procinfo.hpp
@@ -43,6 +43,8 @@ struct SystemInfo {
   int64_t swapfree;
 };
 
+bool ReadProcessInfoWithChildren(int pid, ProcessInfo *procinfo);
+
 bool ReadProcessInfo(int pid, ProcessInfo *s);
 
 bool ReadSystemInfo(SystemInfo *s);

--- a/include/procman_ros/procman_deputy.hpp
+++ b/include/procman_ros/procman_deputy.hpp
@@ -47,7 +47,7 @@ class ProcmanDeputy {
 
     void OnPosixSignal(int signum);
 
-    void OnProcessOutputAvailable(DeputyCommand* mi);
+    void OnProcessOutputAvailable(DeputyCommand* deputy_cmd);
 
     void UpdateCpuTimes();
 
@@ -55,11 +55,11 @@ class ProcmanDeputy {
 
     void TransmitProcessInfo();
 
-    void MaybeScheduleRespawn(DeputyCommand *mi);
+    void MaybeScheduleRespawn(DeputyCommand *deputy_cmd);
 
-    int StartCommand(DeputyCommand* mi, int desired_runid);
+    int StartCommand(DeputyCommand* deputy_cmd, int desired_runid);
 
-    int StopCommand(DeputyCommand* mi);
+    int StopCommand(DeputyCommand* deputy_cmd);
 
     void TransmitStr(const std::string& command_id, const char* str);
 

--- a/include/procman_ros/procman_deputy.hpp
+++ b/include/procman_ros/procman_deputy.hpp
@@ -77,7 +77,8 @@ class ProcmanDeputy {
 
     std::string deputy_id_;
 
-    SystemInfo cpu_time_[2];
+    SystemInfo current_system_status;
+    SystemInfo previous_system_status;
     float cpu_load_;
 
     int64_t deputy_start_time_;

--- a/src/procman/procinfo_linux.cpp
+++ b/src/procman/procinfo_linux.cpp
@@ -2,17 +2,16 @@
  * code for reading detailed process information on a GNU/Llinux system
  */
 
-#include <stdio.h>
-#include <unistd.h>
-#include <string.h>
-#include <ctype.h>
-#include <string.h>
-#include <stdlib.h>
-#include <limits.h>
-#include <inttypes.h>
 #include <assert.h>
-#include <sys/types.h>
+#include <ctype.h>
 #include <dirent.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include <map>
 
@@ -20,19 +19,20 @@
 
 namespace procman {
 
-static void strsplit (char *buf, char **words, int maxwords) {
+static void strsplit(char *buf, char **words, int maxwords) {
   int inword = 0;
   int i;
   int wordind = 0;
-  for (i=0; buf[i] != 0; i++) {
-    if (isspace (buf[i])) {
+  for (i = 0; buf[i] != 0; i++) {
+    if (isspace(buf[i])) {
       inword = 0;
       buf[i] = 0;
     } else {
-      if (! inword) {
+      if (!inword) {
         words[wordind] = buf + i;
         wordind++;
-        if (wordind >= maxwords) break;
+        if (wordind >= maxwords)
+          break;
         inword = 1;
       }
     }
@@ -47,25 +47,26 @@ struct PidInfo {
   int session;
   char state;
 
-  std::vector<PidInfo*> children;
+  std::vector<PidInfo *> children;
 };
 
-bool GetPidInfo(int pid, PidInfo* result) {
+bool GetPidInfo(int pid, PidInfo *result) {
   result->pid = pid;
   result->children.clear();
 
   char fname[40];
   snprintf(fname, 40, "/proc/%d/stat", pid);
-  FILE* fp = fopen(fname, "r");
-  if(!fp) {
+  FILE *fp = fopen(fname, "r");
+  if (!fp) {
     return false;
   }
   int read_pid;
   char exec_name[PATH_MAX + 1];
-  int numwords = fscanf(fp, "%d %s %c %d %d %d", &read_pid, exec_name,
-      &result->state, &result->ppid, &result->pgrp, &result->session);
+  int numwords =
+      fscanf(fp, "%d %s %c %d %d %d", &read_pid, exec_name, &result->state,
+             &result->ppid, &result->pgrp, &result->session);
   fclose(fp);
-  if(6 != numwords) {
+  if (6 != numwords) {
     return false;
   }
   return true;
@@ -76,32 +77,30 @@ bool IsOrphanedChildOf(int orphan, int parent) {
   if (!GetPidInfo(orphan, &pinfo)) {
     return false;
   }
-  return (pinfo.ppid == 1 &&
-      pinfo.pgrp == parent &&
-      pinfo.session == parent);
+  return (pinfo.ppid == 1 && pinfo.pgrp == parent && pinfo.session == parent);
 }
 
 static std::map<int, PidInfo> get_all_pids_and_ppids() {
   std::map<int, PidInfo> result;
-  DIR* procdir = opendir("/proc");
+  DIR *procdir = opendir("/proc");
   if (!procdir) {
     return result;
   }
 
-  struct dirent* entry;
+  struct dirent *entry;
   for (entry = readdir(procdir); entry; entry = readdir(procdir)) {
     const int pid = atoi(entry->d_name);
-    if(!pid) {
+    if (!pid) {
       continue;
     }
     result[pid] = PidInfo();
-    PidInfo& pinfo = result[pid];
+    PidInfo &pinfo = result[pid];
     if (!GetPidInfo(pid, &pinfo)) {
       continue;
     }
     auto iter = result.find(pinfo.ppid);
     if (iter != result.end()) {
-      PidInfo& parent = iter->second;
+      PidInfo &parent = iter->second;
       parent.children.push_back(&pinfo);
     }
   }
@@ -109,9 +108,9 @@ static std::map<int, PidInfo> get_all_pids_and_ppids() {
   return result;
 }
 
-static void pid_info_get_descendants(const PidInfo& pinfo,
-    std::vector<int>* result) {
-  for (PidInfo* child : pinfo.children) {
+static void pid_info_get_descendants(const PidInfo &pinfo,
+                                     std::vector<int> *result) {
+  for (PidInfo *child : pinfo.children) {
     assert(child->ppid == pinfo.pid);
     result->push_back(child->pid);
     pid_info_get_descendants(*child, result);
@@ -124,126 +123,146 @@ std::vector<int> GetDescendants(int pid) {
   std::map<int, PidInfo> pid_graph = get_all_pids_and_ppids();
   auto iter = pid_graph.find(pid);
   if (iter != pid_graph.end()) {
-    PidInfo& root = iter->second;
+    PidInfo &root = iter->second;
     pid_info_get_descendants(root, &result);
   }
   return result;
 }
 
+bool ReadProcessInfoWithChildren(int pid, ProcessInfo *procinfo) {
+  if (!ReadProcessInfo(pid, procinfo)) {
+    return false;  
+  }
+
+  std::vector<int> child_pids = GetDescendants(pid);
+
+  for (int child_pid : child_pids) {
+    ProcessInfo info;  
+    ReadProcessInfo(child_pid, &info);
+    procinfo->user += info.user;
+    procinfo->system += info.system;
+    procinfo->vsize += info.vsize;
+    procinfo->rss += info.rss;
+    procinfo->shared += info.shared;
+    procinfo->data += info.data;
+    procinfo->text += info.text;
+  }
+
+  return true;
+}
+
 bool ReadProcessInfo(int pid, ProcessInfo *procinfo) {
-  memset (procinfo, 0, sizeof (ProcessInfo));
+  memset(procinfo, 0, sizeof(ProcessInfo));
   char fname[80];
-  sprintf (fname, "/proc/%d/stat", pid);
-  FILE *fp = fopen (fname, "r");
-  if (! fp) {
+  sprintf(fname, "/proc/%d/stat", pid);
+  FILE *fp = fopen(fname, "r");
+  if (!fp) {
     return false;
   }
 
   char buf[4096];
-  if(!fgets (buf, sizeof (buf), fp)) {
+  if (!fgets(buf, sizeof(buf), fp)) {
     return false;
   }
   char *words[50];
-  memset (words, 0, sizeof(words));
-  strsplit (buf, words, 50);
+  memset(words, 0, sizeof(words));
+  strsplit(buf, words, 50);
 
-  procinfo->user = atoi (words[13]);
-  procinfo->system = atoi (words[14]);
-  procinfo->vsize = strtoll (words[22], NULL, 10);
-  procinfo->rss = strtoll (words[23], NULL, 10) * getpagesize();
+  procinfo->user = atoi(words[13]);
+  procinfo->system = atoi(words[14]);
+  procinfo->vsize = strtoll(words[22], NULL, 10);
+  procinfo->rss = strtoll(words[23], NULL, 10) * getpagesize();
 
-  fclose (fp);
+  fclose(fp);
 
-  sprintf (fname, "/proc/%d/statm", pid);
-  fp = fopen (fname, "r");
-  if (! fp) {
+  sprintf(fname, "/proc/%d/statm", pid);
+  fp = fopen(fname, "r");
+  if (!fp) {
     return false;
   }
 
-  if(!fgets (buf, sizeof(buf), fp)) {
+  if (!fgets(buf, sizeof(buf), fp)) {
     return false;
   }
-  memset (words, 0, sizeof(words));
-  strsplit (buf, words, 50);
+  memset(words, 0, sizeof(words));
+  strsplit(buf, words, 50);
 
-  procinfo->shared = atoi (words[2]) * getpagesize();
-  procinfo->text = atoi (words[3]) * getpagesize();
-  procinfo->data = atoi (words[5]) * getpagesize();
+  procinfo->shared = atoi(words[2]) * getpagesize();
+  procinfo->text = atoi(words[3]) * getpagesize();
+  procinfo->data = atoi(words[5]) * getpagesize();
 
-  fclose (fp);
+  fclose(fp);
   return true;
 }
 
 bool ReadSystemInfo(SystemInfo *sysinfo) {
-  memset (sysinfo, 0, sizeof(SystemInfo));
-  FILE *fp = fopen ("/proc/stat", "r");
-  if (! fp) {
+  memset(sysinfo, 0, sizeof(SystemInfo));
+  FILE *fp = fopen("/proc/stat", "r");
+  if (!fp) {
     return false;
   }
 
   char buf[4096];
   char tmp[80];
 
-  while (! feof (fp)) {
-    if(!fgets (buf, sizeof (buf), fp)) {
-      if(feof(fp))
+  while (!feof(fp)) {
+    if (!fgets(buf, sizeof(buf), fp)) {
+      if (feof(fp))
         break;
       else
         return false;
     }
 
-    if (! strncmp (buf, "cpu ", 4)) {
-      sscanf (buf, "%s %u %u %u %u",
-          tmp,
-          &sysinfo->user,
-          &sysinfo->user_low,
-          &sysinfo->system,
-          &sysinfo->idle);
+    if (!strncmp(buf, "cpu ", 4)) {
+      sscanf(buf, "%s %u %u %u %u", tmp, &sysinfo->user, &sysinfo->user_low,
+             &sysinfo->system, &sysinfo->idle);
       break;
     }
   }
-  fclose (fp);
+  fclose(fp);
 
-  fp = fopen ("/proc/meminfo", "r");
-  if (! fp) {
+  fp = fopen("/proc/meminfo", "r");
+  if (!fp) {
     return false;
   }
-  while (! feof (fp)) {
+  while (!feof(fp)) {
     char units[10];
-    memset (units,0,sizeof(units));
-    if(!fgets (buf, sizeof (buf), fp)) {
-      if(feof(fp)) {
+    memset(units, 0, sizeof(units));
+    if (!fgets(buf, sizeof(buf), fp)) {
+      if (feof(fp)) {
         break;
       } else {
         return false;
       }
     }
 
-    if (! strncmp ("MemTotal:", buf, strlen ("MemTotal:"))) {
-      sscanf (buf, "MemTotal: %" PRId64" %9s", &sysinfo->memtotal, units);
+    if (!strncmp("MemTotal:", buf, strlen("MemTotal:"))) {
+      sscanf(buf, "MemTotal: %" PRId64 " %9s", &sysinfo->memtotal, units);
       sysinfo->memtotal *= 1024;
-    } else if (! strncmp ("MemFree:", buf, strlen ("MemFree:"))) {
-      sscanf (buf, "MemFree: %" PRId64" %9s", &sysinfo->memfree, units);
+    } else if (!strncmp("MemFree:", buf, strlen("MemFree:"))) {
+      sscanf(buf, "MemFree: %" PRId64 " %9s", &sysinfo->memfree, units);
       sysinfo->memfree *= 1024;
-    } else if (! strncmp ("SwapTotal:", buf, strlen("SwapTotal:"))) {
-      sscanf (buf, "SwapTotal: %" PRId64" %9s", &sysinfo->swaptotal, units);
+    } else if (!strncmp("SwapTotal:", buf, strlen("SwapTotal:"))) {
+      sscanf(buf, "SwapTotal: %" PRId64 " %9s", &sysinfo->swaptotal, units);
       sysinfo->swaptotal *= 1024;
-    } else if (! strncmp ("SwapFree:", buf, strlen("SwapFree:"))) {
-      sscanf (buf, "SwapFree: %" PRId64" %9s", &sysinfo->swapfree, units);
+    } else if (!strncmp("SwapFree:", buf, strlen("SwapFree:"))) {
+      sscanf(buf, "SwapFree: %" PRId64 " %9s", &sysinfo->swapfree, units);
       sysinfo->swapfree *= 1024;
     } else {
       continue;
     }
 
-    if (0 != strcmp (units, "kB")) {
-      fprintf (stderr, "unknown units [%s] while reading "
-          "/proc/meminfo!!!\n", units);
+    if (0 != strcmp(units, "kB")) {
+      fprintf(stderr,
+              "unknown units [%s] while reading "
+              "/proc/meminfo!!!\n",
+              units);
     }
   }
 
-  fclose (fp);
+  fclose(fp);
 
   return true;
 }
 
-}  // namespace procman
+} // namespace procman

--- a/src/procman_ros/procman_deputy.cpp
+++ b/src/procman_ros/procman_deputy.cpp
@@ -450,15 +450,13 @@ void ProcmanDeputy::UpdateCpuTimes() {
     DeputyCommand *deputy_cmd = item.second;
 
     if (sheriff_cmd->Pid()) {
-      if (!ReadProcessInfo(sheriff_cmd->Pid(), &deputy_cmd->current_status)) {
+      if (!ReadProcessInfoWithChildren(sheriff_cmd->Pid(), &deputy_cmd->current_status)) {
         deputy_cmd->cpu_usage = 0;
         deputy_cmd->current_status.vsize = 0;
         deputy_cmd->current_status.rss = 0;
         perror("update_cpu_times - procinfo_read_proc_cpu_mem");
         // TODO handle this error
       } else {
-        std::vector<int> descendants = GetDescendants(sheriff_cmd->Pid());
-
         uint64_t used_jiffies = deputy_cmd->current_status.user -
                                 deputy_cmd->previous_status.user +
                                 deputy_cmd->current_status.system -


### PR DESCRIPTION
This fixes #6.

The core change here is `ReadProcessInfoWithChildren` in procinfo_linux. I also modified some of the variable names in the deputy to make it easier to understand what is going on, and applied some formatting.

Before, only shows the memory usage of the roslaunch process:

![Screenshot from 2020-07-08 10-23-27](https://user-images.githubusercontent.com/636456/86902038-4ed80a80-c105-11ea-8c08-f2d6dfac56e9.png)

After, shows sum of memory usage of roslaunch process and the nodes that it spawned:

![Screenshot from 2020-07-08 10-12-07](https://user-images.githubusercontent.com/636456/86902047-54cdeb80-c105-11ea-95bd-00641eff4ddd.png)
