### PR TITLE
roscore no longer persists by default after sheriff/deputy exit

### DIFF
--- a/python/src/procman_ros/sheriff_gtk/sheriff_gtk.py
+++ b/python/src/procman_ros/sheriff_gtk/sheriff_gtk.py
@@ -753,7 +753,7 @@ def main():
                 "roscore",
                 stdout=devnull,  # TODO should be subprocess.DEVNULL in >3.3
                 stderr=devnull,
-                preexec_fn=preexec
+                preexec_fn=preexec,
             )
             # allow a bit of time to start the core so that we don't get a warning
             import time
@@ -806,7 +806,7 @@ def main():
             gtk.main()
         except KeyboardInterrupt:
             print("Exiting")
-        gui.cleanup(True)
+            gui.cleanup(True)
     else:
         if not args.script:
             print("No script specified and running in headless mode.  Exiting")


### PR DESCRIPTION
There is a flag `--persist-roscore` if this behaviour is desired. By default the roscore is started, but it will not live beyond the lifetime of the sheriff or deputy process, if either of them started a roscore.

Changes the roscore behaviour so that by default its behaviour is:

- If no roscore is running, sheriff/deputy will start it
- if a roscore was started by the sheriff/deputy and the corresponding process exits, then the roscore will stop

This results in some situations where there are problems which might be impossible to fix, specifically:

- Start a standalone deputy with `rosrun procman_ros deputy -i localhost` - this process will start a roscore
- Start a standalone sheriff with `rosrun procman_ros sheriff robot.pmd`
- Stop the deputy and restart it.

The sheriff will not be able to see the deputy because the roscore that it was previously connected to no longer exists. I don't know if it's possible for a node to reconnect to a roscore which has died. All subscribers/publishers must be reconnected, and the node must be initialised again.

This might cause problems if the robot goes out of wifi range and the roscore is lost? The sheriff lives on the operator machine and connects to the deputy on the robot, where the roscore lives. Or is it the case that if the roscore is still the same instance the node will reconnect once it can see the network again?