### PR TITLE
Fix background/text color and typo

### DIFF
--- a/python/src/procman_ros/sheriff_gtk/command_console.py
+++ b/python/src/procman_ros/sheriff_gtk/command_console.py
@@ -120,15 +120,15 @@ class SheriffCommandConsole(Gtk.ScrolledWindow, SheriffListener):
 
     def set_background_color(self, color):
         self.base_color = color
-        self.stdout_textview.modify_base(Gtk.StateType.NORMAL, color)
-        self.stdout_textview.modify_base(Gtk.StateType.ACTIVE, color)
-        self.stdout_textview.modify_base(Gtk.StateType.PRELIGHT, color)
+        self.stdout_textview.override_background_color(Gtk.StateFlags.NORMAL, Gdk.RGBA.from_color(color))
+        self.stdout_textview.override_background_color(Gtk.StateFlags.ACTIVE, Gdk.RGBA.from_color(color))
+        self.stdout_textview.override_background_color(Gtk.StateFlags.PRELIGHT, Gdk.RGBA.from_color(color))
 
     def set_text_color(self, color):
         self.text_color = color
-        self.stdout_textview.modify_text(Gtk.StateType.NORMAL, color)
-        self.stdout_textview.modify_text(Gtk.StateType.ACTIVE, color)
-        self.stdout_textview.modify_text(Gtk.StateType.PRELIGHT, color)
+        self.stdout_textview.override_color(Gtk.StateFlags.NORMAL, Gdk.RGBA.from_color(color))
+        self.stdout_textview.override_color(Gtk.StateFlags.ACTIVE, Gdk.RGBA.from_color(color))
+        self.stdout_textview.override_color(Gtk.StateFlags.PRELIGHT, Gdk.RGBA.from_color(color))
 
     def set_font(self, font_str):
         self.font_str = font_str
@@ -236,7 +236,7 @@ class SheriffCommandConsole(Gtk.ScrolledWindow, SheriffListener):
         sep = Gtk.SeparatorMenuItem()
         menu.append(sep)
         sep.show()
-        mi = Gtk.MenuItem("_Clear")
+        mi = Gtk.MenuItem("Clear")
         menu.append(mi)
         mi.connect("activate", self._tb_clear)
         mi.show()


### PR DESCRIPTION
Hi @heuristicus , this tries to fix minor things:

- A minor typo in the clear command (it used to say `_Clear`)
- The GTK methods used to change the background and font color in the Sheriff's command console, since the API changed and it was not working. While they work in Noetic, the `override_background_color` and `override_color` methods are also deprecated in favor of CSS-based formatting (I guess that's like Qt). However, I did a quick search I couldn't find a good example to implement it myself. Do you have any experience with this?