### PR TITLE
Fix bug in headless mode

### DIFF
--- a/python/src/procman_ros/sheriff_cli.py
+++ b/python/src/procman_ros/sheriff_cli.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import argparse
 import os
 import signal
@@ -97,6 +99,8 @@ class SheriffHeadless(ScriptListener):
             if self.script:
                 time.sleep(0.2)
                 self._start_script()
+                while self.script_manager._active_script_context is not None:
+                    time.sleep(0.2)
         except KeyboardInterrupt:
             pass
         except OSError:


### PR DESCRIPTION
Before this PR, when running a script through procman in headless mode, procman didn't wait for the script to finish. This meant scripts were often only partially executed.

This PR keeps procman alive until the script has finished executing,

This addresses #31.